### PR TITLE
Fix upload chunks in upload.js

### DIFF
--- a/upload.js
+++ b/upload.js
@@ -27,7 +27,12 @@ function getChunkSize() {
 
 export async function selectFile(file) {
     const { taskId, chunkSize, totalChunks, fileHash, chunkHashes, uploadedChunks } = await createUploadTask(file);
-    await uploadChunks(file, { chunkSize, totalChunks, taskId, chunkHashes, uploadedChunks });
+    if (totalChunks === 1) {
+        await uploadChunk(file, taskId, chunkHashes, chunkSize, 0);
+        await requestMerge(taskId);
+    } else {
+        await uploadChunks(file, { chunkSize, totalChunks, taskId, chunkHashes, uploadedChunks });
+    }
 }
 
 async function createUploadTask(file) {


### PR DESCRIPTION
Modify `selectFile` function to handle the case when there is only one chunk.

* Check if `totalChunks` is 1 and directly call `uploadChunk` and `requestMerge`.
* Otherwise, call `uploadChunks` as usual.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChenHom/js-implement-file-slicing-upload-resumable-uploads/pull/2?shareId=94646df8-5c4d-4ae6-8f16-c46f4925eb4c).