### PR TITLE
Fix upload reset after merging chunks

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,6 +28,13 @@
                 alert('請選擇一個檔案');
             }
         });
+
+        function resetFileInput() {
+            const fileInput = document.getElementById('fileInput');
+            if (fileInput) {
+                fileInput.value = '';
+            }
+        }
     </script>
 </body>
 </html>

--- a/service/main.go
+++ b/service/main.go
@@ -324,6 +324,9 @@ func uploadChunk(w http.ResponseWriter, r *http.Request) {
             return
         }
 
+        // 更新 task.UploadedChunks
+        task.UploadedChunks = uploadedChunks
+
         logger.WithFields(logrus.Fields{
             "task_id":    chunk.TaskID,
             "chunk_index": chunk.ChunkIndex,

--- a/upload.js
+++ b/upload.js
@@ -217,6 +217,16 @@ async function requestMerge(taskId) {
         if (!response.ok) throw new Error('合併分片失敗');
         const { downloadUrl } = await response.json();
         console.log('上傳完成，下載連結:', downloadUrl);
+
+        // 清除 localStorage
+        localStorage.clear();
+
+        // 重置 file input 元素
+        const fileInput = document.getElementById('fileInput');
+        if (fileInput) {
+            fileInput.value = '';
+        }
+
         return downloadUrl;
     } catch (error) {
         console.error('完成上傳失敗', error);


### PR DESCRIPTION
Add logic to clear localStorage and reset file input after merging slices.

* **upload.js**
  - Add a call to `localStorage.clear()` after merging the chunks in the `requestMerge` function.
  - Add a call to reset the file input element after merging the chunks in the `requestMerge` function.

* **index.html**
  - Add a function to reset the file input element after the upload is complete.

* **service/main.go**
  - Update `task.UploadedChunks` after merging the slices.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/ChenHom/js-implement-file-slicing-upload-resumable-uploads/pull/4?shareId=16e128bc-746f-4eae-9517-ce9ba63f1c34).